### PR TITLE
Admin: Enable contact deactivation (SHOOP-2236)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -111,6 +111,7 @@ Addons
 Front
 ~~~~~
 
+- Add login check for inactive contacts
 - Remove "Ordering for company" from checkout if logged in
 - Allow user to link company contact from account page
 - Log-in as company if user is a member of a company

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -73,6 +73,7 @@ Localization
 Admin
 ~~~~~
 
+- Enable contact activation/deactivation
 - Allow contact adding and removing for company
 - Show companies in person contact edit page
 - Add target option to ``SearchResult``

--- a/shoop/admin/locale/en/LC_MESSAGES/django.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-01 12:26+0000\n"
+"POT-Creation-Date: 2016-06-03 18:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -146,7 +146,29 @@ msgstr ""
 msgid "Create an user for the contact."
 msgstr ""
 
+msgid "Activate Contact"
+msgstr ""
+
+msgid "Deactivate Contact"
+msgstr ""
+
 msgid "Edit..."
+msgstr ""
+
+msgid "You can not deactivate a superuser."
+msgstr ""
+
+msgid "You can not deactivate yourself."
+msgstr ""
+
+#, python-format
+msgid "%(contact)s is now %(state)s."
+msgstr ""
+
+msgid "active"
+msgstr ""
+
+msgid "inactive"
 msgstr ""
 
 msgid "Person"
@@ -779,20 +801,8 @@ msgstr ""
 msgid "User bound to contact %(contact)s."
 msgstr ""
 
-msgid "You can not deactivate a superuser."
-msgstr ""
-
-msgid "You can not deactivate yourself."
-msgstr ""
-
 #, python-format
 msgid "%(user)s is now %(state)s."
-msgstr ""
-
-msgid "active"
-msgstr ""
-
-msgid "inactive"
 msgstr ""
 
 msgid "Username"

--- a/shoop/core/models/_contacts.py
+++ b/shoop/core/models/_contacts.py
@@ -359,7 +359,7 @@ def get_person_contact(user):
         'last_name': getattr(user, 'last_name', ''),
         'email': getattr(user, 'email', ''),
     }
-    return PersonContact.objects.get_or_create(user=user, defaults=defaults)[0]
+    return PersonContact.objects.filter(is_active=True).get_or_create(user=user, defaults=defaults)[0]
 
 
 def get_company_contact(user):
@@ -378,4 +378,4 @@ def get_company_contact(user):
     contact = get_person_contact(user)
     if not contact:
         return None
-    return contact.company_memberships.first()
+    return contact.company_memberships.filter(is_active=True).first()

--- a/shoop/front/apps/auth/forms.py
+++ b/shoop/front/apps/auth/forms.py
@@ -51,6 +51,18 @@ class EmailAuthenticationForm(AuthenticationForm):
 
         return username
 
+    def confirm_login_allowed(self, user):
+        """
+        If a user has a contact that has been disabled by admin, do not let
+        user login.
+        """
+        if hasattr(user, "contact") and not user.contact.is_active:
+            raise forms.ValidationError(
+                self.error_messages['inactive'],
+                code='inactive',
+            )
+        super(EmailAuthenticationForm, self).confirm_login_allowed(user)
+
 
 class RecoverPasswordForm(forms.Form):
     username = forms.CharField(label=_("Username"), max_length=254, required=False)

--- a/shoop_tests/admin/test_contact_module.py
+++ b/shoop_tests/admin/test_contact_module.py
@@ -8,7 +8,10 @@
 import pytest
 
 from shoop.admin.modules.contacts import ContactModule
-from shoop.testing.factories import create_random_person
+from shoop.admin.modules.contacts.views.detail import ContactDetailView
+from shoop.core.models import Contact
+from shoop.testing.factories import create_random_person, get_default_shop
+from shoop.testing.utils import apply_request_middleware
 from shoop_tests.utils import empty_iterable
 
 
@@ -22,3 +25,20 @@ def test_contact_module_search(rf):
     assert not empty_iterable(cm.get_search_results(request, query=contact.email))
     assert not empty_iterable(cm.get_search_results(request, query=contact.first_name))
     assert empty_iterable(cm.get_search_results(request, query=contact.email[0]))
+
+
+@pytest.mark.django_db
+def test_contact_set_is_active(rf, admin_user):
+    get_default_shop()
+    contact = create_random_person(locale="en_US", minimum_name_comp_len=5)
+    assert contact.is_active
+
+    request = apply_request_middleware(rf.post("/", {"set_is_active": "0"}), user=admin_user)
+    view_func = ContactDetailView.as_view()
+    response = view_func(request, pk=contact.pk)
+    assert response.status_code < 500 and not Contact.objects.get(pk=contact.pk).is_active
+
+    request = apply_request_middleware(rf.post("/", {"set_is_active": "1"}), user=admin_user)
+    view_func = ContactDetailView.as_view()
+    response = view_func(request, pk=contact.pk)
+    assert response.status_code < 500 and Contact.objects.get(pk=contact.pk).is_active


### PR DESCRIPTION
Add a login check so that inactive contacts cannot log into front.

Enable contact deactivation from Contact list view under Shoop Admin.

Refs SHOOP-2236