### PR TITLE
Front: Remove "Ordering for company" from checkout if logged in

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -110,6 +110,7 @@ Addons
 Front
 ~~~~~
 
+- Remove "Ordering for company" from checkout if logged in
 - Allow user to link company contact from account page
 - Log-in as company if user is a member of a company
 - Make ``get_product_cross_sells`` faster

--- a/shoop/front/checkout/addresses.py
+++ b/shoop/front/checkout/addresses.py
@@ -60,7 +60,7 @@ class AddressesPhase(CheckoutPhaseViewMixin, FormView):
         fg = FormGroup(**self.get_form_kwargs())
         for kind in self.address_kinds:
             fg.add_form_def(kind, form_class=self.address_form_classes.get(kind, self.address_form_class))
-        if self.company_form_class:
+        if self.company_form_class and not self.request.customer:
             fg.add_form_def("company", self.company_form_class, required=False)
         return fg
 


### PR DESCRIPTION
Only add company info form fields if user is not logged in
Ref SHOOP-2643