### PR TITLE
Admin: Add product price rounding in order edit (SHOOP-2640)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -73,6 +73,7 @@ Localization
 Admin
 ~~~~~
 
+- Add product price rounding in order edit
 - Add default ``is_active`` filter to Contact and User admins
 - Enable default values for ``ChoiceFilter``
 - Enable contact activation/deactivation

--- a/shoop/admin/modules/orders/views/edit.py
+++ b/shoop/admin/modules/orders/views/edit.py
@@ -99,8 +99,8 @@ def get_line_data_for_edit(shop, line):
         "text": line.text,
         "quantity": line.quantity,
         "sku": line.sku,
-        "baseUnitPrice": line.base_unit_price.value,
-        "unitPrice": total_price / line.quantity if line.quantity else 0,
+        "baseUnitPrice": "{:.2f}".format(line.base_unit_price.value),
+        "unitPrice": "{:.2f}".format((total_price / line.quantity) if line.quantity else 0),
         "unitPriceIncludesTax": shop.prices_include_tax,
         "errors": "",
         "step": ""
@@ -239,11 +239,11 @@ class OrderEditView(CreateOrUpdateView):
                 "name": force_text(product.tax_class),
             },
             "baseUnitPrice": {
-                "value": price_info.base_price.value,
+                "value": "{:.2f}".format(price_info.base_price.value),
                 "includesTax": price_info.base_price.includes_tax
             },
             "unitPrice": {
-                "value": price_info.price.value,
+                "value": "{:.2f}".format(price_info.price.value),
                 "includesTax": price_info.price.includes_tax
             }
         }


### PR DESCRIPTION
Round product prices to 2 decimals since the total is also rounded and more
than 2 decimals will cause problems with discounts.